### PR TITLE
Add optional 'disablelogging' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,24 +16,61 @@ function SonoffTasmotaSwitchHTTPAccessory(log, config) {
   this.hostname = config["hostname"] || "sonoff";
   this.password = config["password"] || "";
   this.disablelogging = config["disablelogging"] || false;
+  this.timeout  = config['timeout'] || '200';
   
   this.service = new Service.Switch(this.name);
   
   this.service
-  .getCharacteristic(Characteristic.On)
-  .on('get', this.getState.bind(this))
-  .on('set', this.setState.bind(this));
+    .getCharacteristic(Characteristic.On)
+    .on('get', this.getState.bind(this))
+    .on('set', this.setState.bind(this));
   
   this.log("Sonoff Tasmota Switch HTTP Initialized")
 }
 
 SonoffTasmotaSwitchHTTPAccessory.prototype.getState = function(callback) {
   var that = this
-  request("http://" + that.hostname + "/cm?user=admin&password=" + that.password + "&cmnd=Power" + that.relay, function(error, response, body) {
-    if (error) return callback(error);
+  request({
+    uri: "http://" + that.hostname + "/cm?user=admin&password=" + that.password + "&cmnd=Power" + that.relay, 
+    timeout: that.timeout,
+  }, function(error, response, body) {
+    if (error){
+      return callback(error);
+    }
+    
     var sonoff_reply = JSON.parse(body); // {"POWER":"ON"}
     if(that.disablelogging){
       that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Get State: " + JSON.stringify(sonoff_reply));
+    };
+    switch (sonoff_reply["POWER" + that.relay]) {
+      case "ON":
+        callback(null, 1);
+        break;
+      case "OFF":
+        callback(null, 0);
+        break;
+    }
+  });
+};
+
+SonoffTasmotaSwitchHTTPAccessory.prototype.setState = function(toggle, callback) {
+  var newstate = "%20Off"
+  if (toggle) {
+    newstate = "%20On"
+  }
+
+  var that = this
+  request({
+    uri: "http://" + that.hostname + "/cm?user=admin&password=" + that.password + "&cmnd=Power" + that.relay + newstate, 
+    timeout: that.timeout,
+  }, function(error, response, body) {
+    if (error) {
+      return callback(error);
+    }
+
+    var sonoff_reply = JSON.parse(body); // {"POWER":"ON"}
+    if(that.disablelogging){
+      that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Set State: " + JSON.stringify(sonoff_reply));
     }
     switch (sonoff_reply["POWER" + that.relay]) {
       case "ON":
@@ -46,28 +83,6 @@ SonoffTasmotaSwitchHTTPAccessory.prototype.getState = function(callback) {
   })
 }
 
-SonoffTasmotaSwitchHTTPAccessory.prototype.setState = function(toggle, callback) {
-  var newstate = "%20Off"
-  if (toggle) newstate = "%20On"
-  var that = this
-  request("http://" + that.hostname + "/cm?user=admin&password=" + that.password + "&cmnd=Power" + that.relay + newstate, function(error, response, body) {
-    if (error) return callback(error);
-    var sonoff_reply = JSON.parse(body); // {"POWER":"ON"}
-    if(that.disablelogging){
-      that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Set State: " + JSON.stringify(sonoff_reply));
-    }
-    switch (sonoff_reply["POWER" + that.relay]) {
-      case "ON":
-        callback();
-        break;
-      case "OFF":
-        callback();
-        break;
-    }
-  })
-}
-
 SonoffTasmotaSwitchHTTPAccessory.prototype.getServices = function() {
   return [this.service];
 }
-

--- a/index.js
+++ b/index.js
@@ -11,10 +11,11 @@ module.exports = function(homebridge) {
 function SonoffTasmotaSwitchHTTPAccessory(log, config) {
   this.log = log;
   this.config = config;
-  this.name = config["name"]
-  this.relay = config["relay"] || ""
-  this.hostname = config["hostname"] || "sonoff"
+  this.name = config["name"];
+  this.relay = config["relay"] || "";
+  this.hostname = config["hostname"] || "sonoff";
   this.password = config["password"] || "";
+  this.disablelogging = config["disablelogging"] || false;
   
   this.service = new Service.Switch(this.name);
   
@@ -31,7 +32,9 @@ SonoffTasmotaSwitchHTTPAccessory.prototype.getState = function(callback) {
   request("http://" + that.hostname + "/cm?user=admin&password=" + that.password + "&cmnd=Power" + that.relay, function(error, response, body) {
     if (error) return callback(error);
     var sonoff_reply = JSON.parse(body); // {"POWER":"ON"}
-    that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Get State: " + JSON.stringify(sonoff_reply));
+    if(that.disablelogging){
+      that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Get State: " + JSON.stringify(sonoff_reply));
+    }
     switch (sonoff_reply["POWER" + that.relay]) {
       case "ON":
         callback(null, 1);
@@ -50,7 +53,9 @@ SonoffTasmotaSwitchHTTPAccessory.prototype.setState = function(toggle, callback)
   request("http://" + that.hostname + "/cm?user=admin&password=" + that.password + "&cmnd=Power" + that.relay + newstate, function(error, response, body) {
     if (error) return callback(error);
     var sonoff_reply = JSON.parse(body); // {"POWER":"ON"}
-    that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Set State: " + JSON.stringify(sonoff_reply));
+    if(that.disablelogging){
+      that.log("Sonoff HTTP: " + that.hostname + ", Relay " + that.relay + ", Set State: " + JSON.stringify(sonoff_reply));
+    }
     switch (sonoff_reply["POWER" + that.relay]) {
       case "ON":
         callback();
@@ -65,3 +70,4 @@ SonoffTasmotaSwitchHTTPAccessory.prototype.setState = function(toggle, callback)
 SonoffTasmotaSwitchHTTPAccessory.prototype.getServices = function() {
   return [this.service];
 }
+


### PR DESCRIPTION
Love this plugin; but wanted the option to disable logging (when it's working as expected!), since I like to keep my Homebridge log as clean as possible - allows me to catch real errors early!